### PR TITLE
typo in function name

### DIFF
--- a/day03/ex03/ex03.md
+++ b/day03/ex03/ex03.md
@@ -28,7 +28,7 @@ Authorized operator: *
 Authorized functions : green, blue  
 Authorized operator: -, +  
 
-* `celluloid(array)` : Takes a NumPy array of an image as an argument, and returns an array with a celluloid shade filter.
+* `to_celluloid(array)` : Takes a NumPy array of an image as an argument, and returns an array with a celluloid shade filter.
 The celluloid filter must display at least four thresholds of shades. Be careful! You are not asked to apply black contour on the object here (you will have to, but later...), you only have to work on the shades of your images.  
 Authorized functions: .arange, linspace  
 


### PR DESCRIPTION
Differences between text and sample code (celluloid vs to_celluloid). Later kept for consistency with the apparent naming convention.