### PR TITLE
P0ex01 fixes

### DIFF
--- a/module00/ex01/ex01.md
+++ b/module00/ex01/ex01.md
@@ -11,6 +11,8 @@ Make a program that takes a string as argument, reverses it, swaps its letters c
 
 If more than one argument are provided, merge them into a single string with each argument separated by a space character.
 
+If no argument is provided, print nothing.
+
 **Example:**
 
 ```console


### PR DESCRIPTION
###  python -> python3
   Prevent accidental use of python 2.0

###  "Hello World\!"-> 'Hello World!'
   Switching to single quote prevent an issue where `!` not being interpreted as a special character lead to a `\` being printed, depending on the shell terminal.

### text modification: 
  - changing from `we do` to `it (the program) does`,
  - requirement written in the description instead of using example only,
  - Changing future form to present form

### Linked issue:
#124