### PR TITLE
P0ex02 fixes

### DIFF
--- a/module00/ex02/ex02.md
+++ b/module00/ex02/ex02.md
@@ -13,19 +13,26 @@ If more than one argument are provided or if the argument is not an integer, pri
 
 If no argument is provided, print nothing.
 
+***Hints***: you can handle errors as you want but take a look at `assert`
+
 **Example:**
 
 ```console
-> python3 whois.py 12
+$> python3 whois.py 12
 I'm Even.
-> python3 whois.py 3
+
+$> python3 whois.py 3
 I'm Odd.
-> python3 whois.py 0
+
+$> python3 whois.py 0
 I'm Zero.
-> python3 whois.py 12 3
-ERROR
-> python3 whois.py Hello
-ERROR
-> python3 whois.py
->
+
+$> python3 whois.py
+
+$> python3 whois.py Hello
+AssertionError: argument is not integer
+
+$> python3 whois.py 12 3
+AssertionError: more than one argument is provided
+
 ```

--- a/module00/ex02/ex02.md
+++ b/module00/ex02/ex02.md
@@ -7,9 +7,9 @@
 |   Forbidden functions:  |  None              |
 |   Remarks:              |  n/a               |
 
-Make a program that takes an integer as argument, checks whether it is odd, even or zero, and print the result.
+Make a program that takes a number as argument, checks whether it is odd, even or zero, and print the result.
 
-If more than one argument are provided or if the type of the argument is wrong, print an error message.
+If more than one argument are provided or if the argument is not an integer, print an error message.
 
 If no argument is provided, print nothing.
 
@@ -18,15 +18,14 @@ If no argument is provided, print nothing.
 ```console
 > python3 whois.py 12
 I'm Even.
-> python3 whois.py '3'
+> python3 whois.py 3
 I'm Odd.
 > python3 whois.py 0
 I'm Zero.
-> python3 whois.py
-> python3 whois.py Hello
-ERROR
 > python3 whois.py 12 3
 ERROR
-> python3 whois.py 12.0
+> python3 whois.py Hello
 ERROR
+> python3 whois.py
+>
 ```


### PR DESCRIPTION
### python -> python3
Prevent accidental use of python 2.0

### text modification:
changing from `we do` to `it (the program) does`,
requirement written in the description instead of using example only,
Changing future form to present form

### Note:
Should we take about `int()` here or in the correction subject ? I might be overthinking it but I fear fruitless discussion about number parsing and special form (*1e3, 0xfabe...*).