### PR TITLE
P0ex03 fixes

### DIFF
--- a/module00/ex03/ex03.md
+++ b/module00/ex03/ex03.md
@@ -10,7 +10,7 @@
 ## Part 1: text_analyzer
 Create a function called `text_analyzer` that takes a single string argument and displays the sums of its upper-case characters, lower-case characters, punctuation characters and spaces.
 
-- If nothing is provided as argument, the user is prompted to provide a string (*you may need an adapted default value to handle this case*).
+- If nothing is provided as argument, the user is prompted to provide a string (*think about the most adapted default value*).
 
 - If the argument is not a string, print an error message.
 
@@ -49,9 +49,7 @@ The text contains 8 character(s):
 - 8 lower letter(s)
 - 1 punctuation mark(s)
 - 1 space(s)
->>> text_analyzer(1)
-ERROR
->>> text_analyzer(['Hello'])
+>>> text_analyzer(42)
 ERROR
 >>> print(text_analyzer.__doc__)
 
@@ -62,11 +60,14 @@ ERROR
 
 ## Part 2: \_\_name\_\_ == \_\_main\_\_
 
-In the previous part, you wrote a function that can be imported. Without modifying this function or behavior, update your file so it can be launched as a standalone program.
+In the previous part, you wrote a function that can be used anywhere, including in the console or in another file when properly imported. 
+
+Without changing this behavior, update your file so it can also be launched as a standalone program.
 
 - If more than one argument is provided to this program, print an error message.
 
 - Otherwise, use the `text_analyzer` function.
+
 
 **Example:**
 


### PR DESCRIPTION
### python -> python3
Prevent accidental use of python 2.0

### No more *args needed
 It is no longer required to handle multiple variable in the function. Instead:

### 2nd part: __main__
Added a 2nd part that introduces the __main__ concept. The program must return an error when multiple argument are given and use the function otherwise. It shall still be possible to import the function.

### Others
- Removed a sneaky extra-space in the example
- Use a single line example for the user prompt case.
- Replaced `s` by `(s)` for singular/plural.
- docstring stated to be mandatory
- The function must print an error when a non-string is given as argument

### text modification:
requirement written in the description instead of using example only

### Linked issue:
#124