### PR TITLE
P0ex04 fixes

### DIFF
--- a/module00/ex03/ex03.md
+++ b/module00/ex03/ex03.md
@@ -10,7 +10,7 @@
 ## Part 1: text_analyzer
 Create a function called `text_analyzer` that takes a single string argument and displays the sums of its upper-case characters, lower-case characters, punctuation characters and spaces.
 
-- If nothing is provided as argument, the user is prompted to provide a string (*you may need an adapted default value to handle this case*).
+- If nothing is provided as argument, the user is prompted to provide a string (*think about the most adapted default value*).
 
 - If the argument is not a string, print an error message.
 
@@ -49,9 +49,7 @@ The text contains 8 character(s):
 - 8 lower letter(s)
 - 1 punctuation mark(s)
 - 1 space(s)
->>> text_analyzer(1)
-ERROR
->>> text_analyzer(['Hello'])
+>>> text_analyzer(42)
 ERROR
 >>> print(text_analyzer.__doc__)
 
@@ -62,11 +60,14 @@ ERROR
 
 ## Part 2: \_\_name\_\_ == \_\_main\_\_
 
-In the previous part, you wrote a function that can be imported. Without modifying this function or behavior, update your file so it can be launched as a standalone program.
+In the previous part, you wrote a function that can be used anywhere, including in the console or in another file when properly imported. 
+
+Without changing this behavior, update your file so it can also be launched as a standalone program.
 
 - If more than one argument is provided to this program, print an error message.
 
 - Otherwise, use the `text_analyzer` function.
+
 
 **Example:**
 

--- a/module00/ex03/ex03.md
+++ b/module00/ex03/ex03.md
@@ -7,84 +7,61 @@
 |   Forbidden functions:  |  None              |
 |   Remarks:              |  n/a               |
 
-## Part 1: text_analyzer
-Create a function called `text_analyzer` that takes a single string argument and displays the sums of its upper-case characters, lower-case characters, punctuation characters and spaces.
+Create a function called `text_analyzer` that displays the sums of upper-case characters, lower-case characters, punctuation characters and spaces in a given text.
 
-- If nothing is provided as argument, the user is prompted to provide a string (*think about the most adapted default value*).
+`text_analyzer` will take only one parameter: the text to analyze. You have to handle the case where the text is empty (maybe by setting a default value). If there is no text passed to the function, the user is prompted to give one.
 
-- If the argument is not a string, print an error message.
-
-- This function must have a docstring that explains its behavior.
-
-Use the Python console to test your function.
+Test it in the Python console.
 
 **Example:**
 
 ```console
-> python3
+> python
 >>> from count import text_analyzer
->>> text_analyzer("Python 2.0, released 2000, introduced
+>>> text_analyzer("Python 2.0, released 2000, introduced 
 features like List comprehensions and a garbage collection
 system capable of collecting reference cycles.")
-The text contains 143 character(s):
-- 2 upper letter(s)
-- 113 lower letter(s)
-- 4 punctuation mark(s)
-- 18 space(s)
+The text contains 143 characters:
+- 2 upper letters
+- 113 lower letters
+- 4 punctuation marks
+- 18 spaces
 >>> text_analyzer("Python is an interpreted, high-level,
 general-purpose programming language. Created by Guido van
 Rossum and first released in 1991, Python's design philosophy
 emphasizes code readability with its notable use of significant
 whitespace.")
-The text contains 234 character(s):
-- 5 upper letter(s)
-- 187 lower letter(s)
-- 8 punctuation mark(s)
-- 30 space(s)
+The text contains 234 characters:
+- 5 upper letters
+- 187 lower letters
+- 8 punctuation marks
+- 30 spaces
 >>> text_analyzer()
-What is the text to analyze?
->> Hello World!
-The text contains 8 character(s):
-- 2 upper letter(s)
-- 8 lower letter(s)
-- 1 punctuation mark(s)
-- 1 space(s)
->>> text_analyzer(42)
+What is the text to analyse?
+>> Python is an interpreted, high-level, general-purpose
+programming language. Created by Guido van Rossum and first
+released in 1991, Python's design philosophy emphasizes code
+readability with its notable use of significant whitespace.
+The text contains 234 characters:
+- 5 upper letters
+- 187 lower letters
+- 8 punctuation marks
+- 30 spaces
+```
+
+Handle the case when more than one parameter is given to `text_analyzer`:
+
+```console
+>>> from count import text_analyzer
+>>> text_analyzer("Python", "2.0")
 ERROR
+```
+
+You're free to write your docstring and format it the way you want.
+
+```console
 >>> print(text_analyzer.__doc__)
 
     This function counts the number of upper characters, lower characters,
     punctuation and spaces in a given text.
-```
-
-
-## Part 2: \_\_name\_\_ == \_\_main\_\_
-
-In the previous part, you wrote a function that can be used anywhere, including in the console or in another file when properly imported. 
-
-Without changing this behavior, update your file so it can also be launched as a standalone program.
-
-- If more than one argument is provided to this program, print an error message.
-
-- Otherwise, use the `text_analyzer` function.
-
-
-**Example:**
-
-
-```console
-> python3 count.py 'Hello World!'
-The text contains 8 character(s):
-- 2 upper letter(s)
-- 8 lower letter(s)
-- 1 punctuation mark(s)
-- 1 space(s)
-> python3
->>> from count import text_analyzer
->>> text_analyzer("Hello World!")
-The text contains 8 character(s):
-- 2 upper letter(s)
-- 8 lower letter(s)
-- 1 punctuation mark(s)
-- 1 space(s)
 ```

--- a/module00/ex04/ex04.md
+++ b/module00/ex04/ex04.md
@@ -7,55 +7,74 @@
 |   Forbidden functions:  |  None              |
 |   Remarks:              |  n/a               |
 
-You will have to make a program that prints the results of the four elementary mathematical operations of arithmetic (addition, subtraction, multiplication, division) and the modulo operation. This should be accomplished by writing a function that takes 2 numbers as parameters and returns 5 values, as formatted in the console output below.
+Make a program that takes two integers A and B as arguments.
+
+- Without argument
+
+  the program prints an usage
+- With 1, 3 or more arguments or if one of the argument is not a integer
+  
+  the program print an error message and an usage
+
+
+If the arguments are valid, print the results of the following operations:
+```
+Sum:         A+B
+Difference:  A-B
+Product:     A*B
+Quotient:    A/B
+Remainder:   A%B
+```
+
+If an operation is impossible, print an error message instead of the result.
 
 **Example:**
 
 ```console
-> python operations.py 10 3
+> python3 operations.py 10 3
 Sum:         13
 Difference:  7
 Product:     30
-Quotient:    3.3333333333333335
+Quotient:    3.33333...
 Remainder:   1
 >
-> python operations.py 42 10
+> python3 operations.py 42 10
 Sum:         52
 Difference:  32
 Product:     420
 Quotient:    4.2
 Remainder:   2
 >
-> python operations.py 1 0
+> python3 operations.py 1 0
 Sum:         1
 Difference:  1
 Product:     0
-Quotient:    ERROR (div by zero)
+Quotient:    ERROR (division by zero)
 Remainder:   ERROR (modulo by zero)
 >
-> python operations.py
-Usage: python operations.py <number1> <number2>
+> python3 operations.py
+Usage: python3 operations.py <number1> <number2>
 Example:
-    python operations.py 10 3
+    python3 operations.py 10 3
 >
-> python operations.py 12 10 5
+> python3 operations.py 12 10 5
 InputError: too many arguments
 
-Usage: python operations.py <number1> <number2>
+Usage: python3 operations.py <number1> <number2>
 Example:
-    python operations.py 10 3
+    python3 operations.py 10 3
 >
-> python operations.py "one" "two"
-InputError: only numbers
+> python3 operations.py "one" "two"
+InputError: only integers
 
-Usage: python operations.py <number1> <number2>
+Usage: python3 operations.py <number1> <number2>
 Example:
-    python operations.py 10 3
+    python3 operations.py 10 3
 >
-> python operations.py "512" "63.1"
-InputError: only numbers
+> python3 operations.py 512 63.1
+InputError: only integers
 
-Usage: python operations.py <number1> <number2>
+Usage: python3 operations.py <number1> <number2>
 Example:
-    python operations.py 10 3
+    python3 operations.py 10 3
 ```


### PR DESCRIPTION
### python -> python3
Prevent accidental use of python 2.0

### text modification:
requirement written in the description instead of using example only,
Changing future form to present form

### Replacing number only with integer only
More consistent with ex02 input

### Example:
- Using `...` on arbitrarily long decimal part
- Removing dquote on decimal example to avoid a confusion with string

### Linked issue:
#145